### PR TITLE
[FIX] Optimize CI/CD pipeline and fix artifact download issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
   compressed:
     name: Create Compressed Package
     runs-on: ubuntu-latest
-    needs: [composer]
+    needs: [composer, unit-tests]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     container:
       image: tikiwiki/tikiwiki-ci:8.1-qa
@@ -127,8 +127,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compressed]
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-    container:
-      image: curlimages/curl:latest
     steps:
       - name: Download compressed package
         uses: actions/download-artifact@v4
@@ -153,8 +151,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [upload]
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-    container:
-      image: tikiwiki/tikiwiki-ci:8.1-qa
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Add unit-tests dependency to compressed job for quality gate
- Remove container from upload job to fix artifact download failures
- Remove unnecessary container from release job to improve performance

The curlimages/curl container lacks Node.js dependencies required by actions/download-artifact@v4. The release job doesn't need PHP/ImageMagick. Both jobs work correctly with ubuntu-latest runner which has all required tools."